### PR TITLE
FEAT: Add course video section above description, toggle course photo

### DIFF
--- a/military/app/(site)/courses/[slug]/page.tsx
+++ b/military/app/(site)/courses/[slug]/page.tsx
@@ -8,6 +8,7 @@ import Loading from '@/app/loading';
 import { RiArrowDropRightLine } from 'react-icons/ri';
 import { PortableText } from 'next-sanity';
 import CourseSeriesImage from '@/app/components/CourseSeriesImage';
+import VideoHero from '@/app/components/heroes/VideoHero';
 
 type Params = Promise<{
   slug: string;
@@ -55,12 +56,30 @@ export default async function MilitaryCourse({ params }: { params: Params }) {
       <main>
         <Hero {...heroProps} />
 
-        <div className="flex flex-col items-center gap-5 p-10 sm:p-20 lg:grid lg:grid-cols-2">
-          <CourseSeriesImage
-            courseNumber={course.courseNumber}
-            courseTitle={course.courseTitle}
-            image={course.courseSeriesImage}
-          />
+        {course.muxPlaybackId && (
+          <div className="pt-10">
+            <VideoHero
+              thumbnail={course.videoThumbnail ?? ''}
+              thumbnailHotspot={course.videoThumbnail_hotspot}
+              muxPlaybackId={course.muxPlaybackId}
+            />
+          </div>
+        )}
+
+        <div
+          className={`flex flex-col items-center gap-5 p-10 sm:p-20 ${
+            course.showCourseImage !== false
+              ? 'lg:grid lg:grid-cols-2'
+              : 'mx-auto max-w-4xl'
+          }`}
+        >
+          {course.showCourseImage !== false && (
+            <CourseSeriesImage
+              courseNumber={course.courseNumber}
+              courseTitle={course.courseTitle}
+              image={course.courseSeriesImage}
+            />
+          )}
           <div className="flex flex-col gap-10 text-lg text-zinc-100">
             <div className="flex flex-col gap-5">
               <PortableText value={course.courseDescription} />

--- a/military/app/(site)/courses/[slug]/page.tsx
+++ b/military/app/(site)/courses/[slug]/page.tsx
@@ -51,15 +51,17 @@ export default async function MilitaryCourse({ params }: { params: Params }) {
     author: course.courseFooterAuthor,
   };
 
+  const showCourseImage = course.showCourseImage !== false;
+
   return (
     <Suspense fallback={<Loading />}>
       <main>
         <Hero {...heroProps} />
 
-        {course.muxPlaybackId && (
+        {course.muxPlaybackId && course.videoThumbnail && (
           <div className="pt-10">
             <VideoHero
-              thumbnail={course.videoThumbnail ?? ''}
+              thumbnail={course.videoThumbnail}
               thumbnailHotspot={course.videoThumbnail_hotspot}
               muxPlaybackId={course.muxPlaybackId}
             />
@@ -68,12 +70,10 @@ export default async function MilitaryCourse({ params }: { params: Params }) {
 
         <div
           className={`flex flex-col items-center gap-5 p-10 sm:p-20 ${
-            course.showCourseImage !== false
-              ? 'lg:grid lg:grid-cols-2'
-              : 'mx-auto max-w-4xl'
+            showCourseImage ? 'lg:grid lg:grid-cols-2' : 'mx-auto max-w-4xl'
           }`}
         >
-          {course.showCourseImage !== false && (
+          {showCourseImage && course.courseSeriesImage && (
             <CourseSeriesImage
               courseNumber={course.courseNumber}
               courseTitle={course.courseTitle}

--- a/military/sanity/militarySchemas/course.ts
+++ b/military/sanity/militarySchemas/course.ts
@@ -44,10 +44,35 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: 'videoThumbnail',
+      title: 'Video Thumbnail',
+      type: 'image',
+      description:
+        'Poster image shown before the video plays. If video is left blank, the video section will not display on the course page.',
+      options: {
+        hotspot: true,
+      },
+    }),
+    defineField({
+      name: 'video',
+      title: 'Video (Mux)',
+      type: 'mux.video',
+      description:
+        'Optional course video. If left blank, the video section will not display on the course page.',
+    }),
+    defineField({
+      name: 'showCourseImage',
+      title: 'Show Course Image',
+      type: 'boolean',
+      description:
+        'Toggle the course image on or off. If off, the description and requirements will be centered on the page.',
+      initialValue: true,
+    }),
+    defineField({
       name: 'courseSeriesImage',
       title: 'Course Image',
       type: 'image',
-      validation: (Rule) => Rule.required(),
+      hidden: ({ parent }) => !parent?.showCourseImage,
     }),
     defineField({
       name: 'courseDescription',

--- a/military/sanity/sanity-military-utils.ts
+++ b/military/sanity/sanity-military-utils.ts
@@ -267,7 +267,7 @@ export type GetCourseQuery = {
   videoThumbnail_hotspot?: SanityHotspot;
   muxPlaybackId?: string;
   showCourseImage?: boolean;
-  courseSeriesImage: string;
+  courseSeriesImage?: string;
   courseDescription: PortableTextBlock[];
   courseRequirements: string[];
   courseFooterImage: string;

--- a/military/sanity/sanity-military-utils.ts
+++ b/military/sanity/sanity-military-utils.ts
@@ -239,6 +239,10 @@ const getCourseQuery = groq`*[_type == "course" && slug.current == $slug][0]{
   courseNumber,
   courseTitle,
   "slug": slug.current,
+  "videoThumbnail": videoThumbnail.asset->url,
+  "videoThumbnail_hotspot": videoThumbnail.hotspot,
+  "muxPlaybackId": video.asset->playbackId,
+  showCourseImage,
   "courseSeriesImage": courseSeriesImage.asset->url,
   courseDescription,
   courseRequirements,
@@ -259,6 +263,10 @@ export type GetCourseQuery = {
   courseNumber: string;
   courseTitle: string;
   slug: string;
+  videoThumbnail?: string;
+  videoThumbnail_hotspot?: SanityHotspot;
+  muxPlaybackId?: string;
+  showCourseImage?: boolean;
   courseSeriesImage: string;
   courseDescription: PortableTextBlock[];
   courseRequirements: string[];


### PR DESCRIPTION
## Summary
- Add optional Mux video section above course description (renders only when both video and thumbnail are set)
- Add `showCourseImage` toggle to hide the course image and center the description/requirements
- New `videoThumbnail`, `video` (Mux), and `showCourseImage` fields in the course schema
- `courseSeriesImage` is now optional (hidden when `showCourseImage` is off)

## Test plan
- [x] Create/edit a course in Sanity with a Mux video + thumbnail — verify video section renders
- [x] Leave video blank — verify video section does not render
- [x] Toggle `showCourseImage` off — verify image hides and content centers
- [x] Toggle `showCourseImage` on — verify 2-column grid layout with course image