### PR TITLE
Rebuild pages on a shared block system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # f1-mil-tech-mono
-This is a mono repo for Flight-1.com's Military and Tech Sites. CMS provided by Sanity. 
+
+This is a mono repo for Flight-1.com's Military and Tech Sites. CMS provided by Sanity.
+
+- `military/` — Next.js app for the Military site
+- `tech/` — Next.js app for the Tech site
+
+## Running locally
+
+Each site is its own Next.js app:
+
+```sh
+cd military   # or tech
+npm install
+npm run dev
+```
+
+Requires a `.env.local` in the app directory with the Sanity project vars
+(`NEXT_PUBLIC_MILITARY_SANITY_PROJECT_ID` / `NEXT_PUBLIC_MILITARY_SANITY_DATASET`
+for military; `NEXT_PUBLIC_SANITY_PROJECT_ID` / `NEXT_PUBLIC_SANITY_DATASET` for tech).
+
+## Sanity Studio
+
+The Studio is embedded in each Next.js app at the **`/cms`** route (see
+`sanity.config.ts` → `basePath`), so there is no separate studio server:
+
+- Local: run the dev server, then open <http://localhost:3000/cms>
+- Production: `https://<site-domain>/cms`
+
+Log in with your Sanity account. Schemas live in `military/sanity/militarySchemas/`
+(desk structure in `military/sanity/sanity-military-structure.ts`), and content
+queries in `military/sanity/sanity-military-utils.ts`. After schema changes, run
+`npm run generate` to re-extract the schema and regenerate types.

--- a/military/app/(site)/about/page.tsx
+++ b/military/app/(site)/about/page.tsx
@@ -1,6 +1,7 @@
 import { getAboutPage } from '@/sanity/sanity-military-utils';
 import Hero from '@/app/components/Hero';
 import AboutSection from '@/app/components/AboutSection';
+import BlockRenderer from '@/app/components/BlockRenderer';
 import { Suspense } from 'react';
 import Loading from '@/app/loading';
 
@@ -16,6 +17,7 @@ export default async function MilitaryAboutPage() {
     image1_hotspot,
     image1_title,
     image1_subTitle,
+    sections,
     image3,
     image3_hotspot,
     image3_title,
@@ -51,6 +53,7 @@ export default async function MilitaryAboutPage() {
     <Suspense fallback={<Loading />}>
       <main>
         <Hero {...heroProps} />
+        <BlockRenderer blocks={sections} />
         <AboutSection {...aboutSection2Props} />
         <div className="flex flex-col">
           <AboutSection {...aboutSection3Props} />

--- a/military/app/(site)/about/page.tsx
+++ b/military/app/(site)/about/page.tsx
@@ -1,6 +1,8 @@
-import { getAboutPage } from '@/sanity/sanity-military-utils';
-import Hero from '@/app/components/Hero';
-import AboutSection from '@/app/components/AboutSection';
+import {
+  getAboutPage,
+  getCourses,
+  getSupportingCourses,
+} from '@/sanity/sanity-military-utils';
 import BlockRenderer from '@/app/components/BlockRenderer';
 import { Suspense } from 'react';
 import Loading from '@/app/loading';
@@ -12,53 +14,18 @@ export async function generateMetadata() {
 }
 
 export default async function MilitaryAboutPage() {
-  const {
-    image1,
-    image1_hotspot,
-    image1_title,
-    image1_subTitle,
-    sections,
-    image3,
-    image3_hotspot,
-    image3_title,
-    image3_subTitle,
-    facilities_title,
-    facilities_text,
-    selection_title,
-    selection_text,
-  } = await getAboutPage();
-
-  const heroProps = {
-    image: image1,
-    hotspot: image1_hotspot,
-    title: image1_title,
-    subTitle: image1_subTitle,
-  };
-  const aboutSection2Props = {
-    image: image3,
-    hotspot: image3_hotspot,
-    title: image3_title,
-    subTitle: image3_subTitle,
-  };
-  const aboutSection3Props = {
-    title: facilities_title,
-    subTitle: facilities_text,
-  };
-  const aboutSection4Props = {
-    title: selection_title,
-    subTitle: selection_text,
-  };
+  const { sections } = await getAboutPage();
+  const courses = await getCourses();
+  const supportingCourses = await getSupportingCourses();
 
   return (
     <Suspense fallback={<Loading />}>
       <main>
-        <Hero {...heroProps} />
-        <BlockRenderer blocks={sections} />
-        <AboutSection {...aboutSection2Props} />
-        <div className="flex flex-col">
-          <AboutSection {...aboutSection3Props} />
-          <AboutSection {...aboutSection4Props} />
-        </div>
+        <BlockRenderer
+          blocks={sections}
+          courses={courses}
+          supportingCourses={supportingCourses}
+        />
       </main>
     </Suspense>
   );

--- a/military/app/(site)/courses/page.tsx
+++ b/military/app/(site)/courses/page.tsx
@@ -5,95 +5,26 @@ import {
   getMilitaryCoursesPage,
   getSupportingCourses,
 } from '@/sanity/sanity-military-utils';
-import Link from 'next/link';
 import Loading from '@/app/loading';
-import Hero from '@/app/components/Hero';
-import FooterHero from '@/app/components/FooterHero';
-import CourseGrid from '@/app/components/CourseGrid/CourseGrid';
 import BlockRenderer from '@/app/components/BlockRenderer';
-import { RiArrowDropRightLine } from 'react-icons/ri';
 
 export const metadata: Metadata = {
   title: 'Military Courses Page',
 };
 
 export default async function MilitaryCoursesPage() {
-  const {
-    heroImage,
-    heroImage_hotspot,
-    title,
-    subtitle,
-    titleColor,
-    heroImageQuote,
-    heroImageQuoteAuthor,
-    quoteColor,
-    sections,
-    footerImage,
-    footerImage_hotspot,
-  } = await getMilitaryCoursesPage();
+  const { sections } = await getMilitaryCoursesPage();
   const courses = await getCourses();
   const supportingCourses = await getSupportingCourses();
-
-  const heroProps = {
-    image: heroImage,
-    hotspot: heroImage_hotspot,
-    title: title,
-    subTitle: subtitle,
-    titleColor: titleColor,
-    quote: heroImageQuote,
-    author: heroImageQuoteAuthor,
-    quoteColor: quoteColor,
-  };
-
-  const footerHeroProps = {
-    image: footerImage,
-    hotspot: footerImage_hotspot,
-  };
 
   return (
     <Suspense fallback={<Loading />}>
       <main>
-        <Hero {...heroProps} />
-        <BlockRenderer blocks={sections} />
-        <div className="grid-col-1 grid gap-10 px-4 py-16 text-zinc-400 md:grid-cols-2 md:px-10 lg:pl-64 xl:pl-96">
-          <div className="flex flex-col gap-7 md:gap-3">
-            <h3 className="text-2xl">FLIGHT-1 TRAINING SYSTEM</h3>
-            <ul className="flex flex-col">
-              {courses.map((course) => (
-                <Link
-                  key={course._id}
-                  href={`/courses/${course.slug}`}
-                  className="flex items-center text-xl transition hover:font-normal hover:text-white"
-                >
-                  <RiArrowDropRightLine className="text-4xl" />
-                  {course.courseNumber
-                    ? `${course.courseNumber}M ${course.courseTitle}`
-                    : course.courseTitle}
-                </Link>
-              ))}
-            </ul>
-          </div>
-          <div className="flex flex-col gap-7 md:gap-3">
-            <h3 className="whitespace-nowrap text-2xl">
-              FLIGHT-1 SUPPORTING COURSES
-            </h3>
-            <ul className="flex flex-col">
-              {supportingCourses.map((course) => (
-                <Link
-                  key={course._id}
-                  href={`/courses/supporting-courses/${course.slug}`}
-                  className="flex items-center text-xl transition hover:font-normal hover:text-white"
-                >
-                  <RiArrowDropRightLine className="text-4xl" />
-                  {course.courseTitle}
-                </Link>
-              ))}
-            </ul>
-          </div>
-        </div>
-        <hr className="border-t-1 border-zinc-700" />
-        <CourseGrid completed={[]} />
-        <FooterHero {...footerHeroProps} />
+        <BlockRenderer
+          blocks={sections}
+          courses={courses}
+          supportingCourses={supportingCourses}
+        />
       </main>
     </Suspense>
   );

--- a/military/app/(site)/courses/page.tsx
+++ b/military/app/(site)/courses/page.tsx
@@ -10,6 +10,7 @@ import Loading from '@/app/loading';
 import Hero from '@/app/components/Hero';
 import FooterHero from '@/app/components/FooterHero';
 import CourseGrid from '@/app/components/CourseGrid/CourseGrid';
+import BlockRenderer from '@/app/components/BlockRenderer';
 import { RiArrowDropRightLine } from 'react-icons/ri';
 
 export const metadata: Metadata = {
@@ -26,6 +27,7 @@ export default async function MilitaryCoursesPage() {
     heroImageQuote,
     heroImageQuoteAuthor,
     quoteColor,
+    sections,
     footerImage,
     footerImage_hotspot,
   } = await getMilitaryCoursesPage();
@@ -52,6 +54,7 @@ export default async function MilitaryCoursesPage() {
     <Suspense fallback={<Loading />}>
       <main>
         <Hero {...heroProps} />
+        <BlockRenderer blocks={sections} />
         <div className="grid-col-1 grid gap-10 px-4 py-16 text-zinc-400 md:grid-cols-2 md:px-10 lg:pl-64 xl:pl-96">
           <div className="flex flex-col gap-7 md:gap-3">
             <h3 className="text-2xl">FLIGHT-1 TRAINING SYSTEM</h3>

--- a/military/app/(site)/page.tsx
+++ b/military/app/(site)/page.tsx
@@ -1,59 +1,13 @@
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 import Loading from '@/app/loading';
-import {
-  getLandingPage,
-  HeroBlock,
-} from '@/sanity/sanity-military-utils';
-import {
-  HeroTitle,
-  HeroTitleSubtitle,
-  VideoHero,
-} from '@/app/components/heroes';
+import { getLandingPage } from '@/sanity/sanity-military-utils';
+import BlockRenderer from '@/app/components/BlockRenderer';
 
 export async function generateMetadata() {
   return {
     title: 'Military Landing Page',
   };
-}
-
-function renderHero(hero: HeroBlock) {
-  switch (hero._type) {
-    case 'heroTitle':
-      return (
-        <HeroTitle
-          key={hero._key}
-          image={hero.image}
-          hotspot={hero.hotspot}
-          title={hero.title}
-          titleColor={hero.titleColor}
-        />
-      );
-    case 'heroTitleSubtitle':
-      return (
-        <HeroTitleSubtitle
-          key={hero._key}
-          image={hero.image}
-          hotspot={hero.hotspot}
-          title={hero.title}
-          subTitle={hero.subTitle}
-          titleColor={hero.titleColor}
-        />
-      );
-    case 'videoHero':
-      return (
-        <VideoHero
-          key={hero._key}
-          thumbnail={hero.thumbnail}
-          thumbnailHotspot={hero.hotspot}
-          muxPlaybackId={hero.muxPlaybackId}
-          title={hero.title}
-          autoPlay={hero.autoPlay}
-        />
-      );
-    default:
-      return null;
-  }
 }
 
 export default async function MilitaryLandingPage() {
@@ -63,7 +17,7 @@ export default async function MilitaryLandingPage() {
     return (
       <Suspense fallback={<Loading />}>
         <section>
-          {heroes?.map((hero) => renderHero(hero))}
+          <BlockRenderer blocks={heroes} />
         </section>
       </Suspense>
     );

--- a/military/app/(site)/page.tsx
+++ b/military/app/(site)/page.tsx
@@ -1,7 +1,11 @@
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 import Loading from '@/app/loading';
-import { getLandingPage } from '@/sanity/sanity-military-utils';
+import {
+  getLandingPage,
+  getCourses,
+  getSupportingCourses,
+} from '@/sanity/sanity-military-utils';
 import BlockRenderer from '@/app/components/BlockRenderer';
 
 export async function generateMetadata() {
@@ -13,11 +17,17 @@ export async function generateMetadata() {
 export default async function MilitaryLandingPage() {
   try {
     const { heroes } = await getLandingPage();
+    const courses = await getCourses();
+    const supportingCourses = await getSupportingCourses();
 
     return (
       <Suspense fallback={<Loading />}>
         <section>
-          <BlockRenderer blocks={heroes} />
+          <BlockRenderer
+            blocks={heroes}
+            courses={courses}
+            supportingCourses={supportingCourses}
+          />
         </section>
       </Suspense>
     );

--- a/military/app/components/BlockRenderer.tsx
+++ b/military/app/components/BlockRenderer.tsx
@@ -1,0 +1,55 @@
+import { HeroBlock } from '@/sanity/sanity-military-utils';
+import {
+  HeroTitle,
+  HeroTitleSubtitle,
+  VideoHero,
+} from '@/app/components/heroes';
+
+function renderBlock(block: HeroBlock) {
+  switch (block._type) {
+    case 'heroTitle':
+      return (
+        <HeroTitle
+          key={block._key}
+          image={block.image}
+          hotspot={block.hotspot}
+          title={block.title}
+          titleColor={block.titleColor}
+        />
+      );
+    case 'heroTitleSubtitle':
+      return (
+        <HeroTitleSubtitle
+          key={block._key}
+          image={block.image}
+          hotspot={block.hotspot}
+          title={block.title}
+          subTitle={block.subTitle}
+          titleColor={block.titleColor}
+        />
+      );
+    case 'videoHero':
+      return (
+        <div key={block._key} className="py-5 lg:py-10">
+          <VideoHero
+            thumbnail={block.thumbnail}
+            thumbnailHotspot={block.hotspot}
+            muxPlaybackId={block.muxPlaybackId}
+            title={block.title}
+            autoPlay={block.autoPlay}
+          />
+        </div>
+      );
+    default:
+      return null;
+  }
+}
+
+export default function BlockRenderer({
+  blocks,
+}: {
+  blocks?: HeroBlock[] | null;
+}) {
+  if (!blocks?.length) return null;
+  return <>{blocks.map(renderBlock)}</>;
+}

--- a/military/app/components/BlockRenderer.tsx
+++ b/military/app/components/BlockRenderer.tsx
@@ -1,11 +1,25 @@
-import { HeroBlock } from '@/sanity/sanity-military-utils';
+import {
+  HeroBlock,
+  Course,
+  SupportingCourse,
+} from '@/sanity/sanity-military-utils';
 import {
   HeroTitle,
   HeroTitleSubtitle,
   VideoHero,
 } from '@/app/components/heroes';
+import AboutSection from '@/app/components/AboutSection';
+import Hero from '@/app/components/Hero';
+import FooterHero from '@/app/components/FooterHero';
+import CourseGrid from '@/app/components/CourseGrid/CourseGrid';
+import CourseListSection from '@/app/components/CourseListSection';
 
-function renderBlock(block: HeroBlock) {
+type BlockRendererContext = {
+  courses?: Course[];
+  supportingCourses?: SupportingCourse[];
+};
+
+function renderBlock(block: HeroBlock, context: BlockRendererContext) {
   switch (block._type) {
     case 'heroTitle':
       return (
@@ -40,6 +54,53 @@ function renderBlock(block: HeroBlock) {
           />
         </div>
       );
+    case 'aboutSection':
+      return (
+        <AboutSection
+          key={block._key}
+          image={block.image}
+          hotspot={block.hotspot ?? undefined}
+          title={block.title ?? ''}
+          subTitle={block.subTitle ?? []}
+        />
+      );
+    case 'heroQuote':
+      return (
+        <Hero
+          key={block._key}
+          image={block.image}
+          hotspot={block.hotspot}
+          title={block.title}
+          subTitle={block.subTitle}
+          titleColor={block.titleColor}
+          quote={block.quote}
+          author={block.quoteAuthor}
+          quoteColor={block.quoteColor}
+        />
+      );
+    case 'footerHero':
+      return (
+        <FooterHero
+          key={block._key}
+          image={block.image}
+          hotspot={block.hotspot ?? undefined}
+          quote={block.quote}
+          author={block.quoteAuthor}
+        />
+      );
+    case 'courseGridBlock':
+      return (
+        <CourseGrid key={block._key} completed={[]} light={block.light} />
+      );
+    case 'courseListBlock':
+      return (
+        <CourseListSection
+          key={block._key}
+          courses={context.courses ?? []}
+          supportingCourses={context.supportingCourses ?? []}
+          showDivider={block.showDivider}
+        />
+      );
     default:
       return null;
   }
@@ -47,9 +108,19 @@ function renderBlock(block: HeroBlock) {
 
 export default function BlockRenderer({
   blocks,
+  courses,
+  supportingCourses,
 }: {
   blocks?: HeroBlock[] | null;
+  courses?: Course[];
+  supportingCourses?: SupportingCourse[];
 }) {
   if (!blocks?.length) return null;
-  return <>{blocks.map(renderBlock)}</>;
+  return (
+    <>
+      {blocks.map((block) =>
+        renderBlock(block, { courses, supportingCourses })
+      )}
+    </>
+  );
 }

--- a/military/app/components/CourseListSection.tsx
+++ b/military/app/components/CourseListSection.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+import { RiArrowDropRightLine } from 'react-icons/ri';
+import { Course, SupportingCourse } from '@/sanity/sanity-military-utils';
+
+interface CourseListSectionProps {
+  courses: Course[];
+  supportingCourses: SupportingCourse[];
+  showDivider?: boolean;
+}
+
+export default function CourseListSection({
+  courses,
+  supportingCourses,
+  showDivider = true,
+}: CourseListSectionProps) {
+  return (
+    <>
+      <div className="grid-col-1 grid gap-10 px-4 py-16 text-zinc-400 md:grid-cols-2 md:px-10 lg:pl-64 xl:pl-96">
+        <div className="flex flex-col gap-7 md:gap-3">
+          <h3 className="text-2xl">FLIGHT-1 TRAINING SYSTEM</h3>
+          <ul className="flex flex-col">
+            {courses.map((course) => (
+              <Link
+                key={course._id}
+                href={`/courses/${course.slug}`}
+                className="flex items-center text-xl transition hover:font-normal hover:text-white"
+              >
+                <RiArrowDropRightLine className="text-4xl" />
+                {course.courseNumber
+                  ? `${course.courseNumber}M ${course.courseTitle}`
+                  : course.courseTitle}
+              </Link>
+            ))}
+          </ul>
+        </div>
+        <div className="flex flex-col gap-7 md:gap-3">
+          <h3 className="whitespace-nowrap text-2xl">
+            FLIGHT-1 SUPPORTING COURSES
+          </h3>
+          <ul className="flex flex-col">
+            {supportingCourses.map((course) => (
+              <Link
+                key={course._id}
+                href={`/courses/supporting-courses/${course.slug}`}
+                className="flex items-center text-xl transition hover:font-normal hover:text-white"
+              >
+                <RiArrowDropRightLine className="text-4xl" />
+                {course.courseTitle}
+              </Link>
+            ))}
+          </ul>
+        </div>
+      </div>
+      {showDivider && <hr className="border-t-1 border-zinc-700" />}
+    </>
+  );
+}

--- a/military/app/components/heroes/VideoHero.tsx
+++ b/military/app/components/heroes/VideoHero.tsx
@@ -36,7 +36,19 @@ export default function VideoHero({
   };
 
   return (
-    <div className={`bg-black ${className}`}>
+    <div className={`relative overflow-hidden bg-black ${className}`}>
+      {/* Blurred thumbnail fills the pillarbox area on wide screens where the
+          16:9 video doesn't reach the page edges */}
+      <div className="absolute inset-0 hidden lg:block" aria-hidden>
+        <Image
+          src={thumbnail}
+          alt=""
+          fill
+          sizes="100vw"
+          className="scale-110 object-cover blur-2xl brightness-[0.35]"
+          style={{ objectPosition: backgroundPosition }}
+        />
+      </div>
       <div className="relative mx-auto aspect-video w-full overflow-hidden lg:max-h-[60vh] lg:max-w-[106.67vh]">
 
       {/* Thumbnail backdrop — always visible when autoPlay to prevent black flash */}

--- a/military/sanity/militarySchemas/heroes/aboutSection.ts
+++ b/military/sanity/militarySchemas/heroes/aboutSection.ts
@@ -1,0 +1,40 @@
+import { defineField, defineType } from 'sanity';
+
+export default defineType({
+  name: 'aboutSection',
+  title: 'About Section',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+      options: {
+        hotspot: true,
+      },
+    }),
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+    }),
+    defineField({
+      name: 'subTitle',
+      title: 'Body',
+      type: 'array',
+      of: [{ type: 'block' }],
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      media: 'image',
+    },
+    prepare({ title, media }) {
+      return {
+        title: title || 'About Section',
+        media,
+      };
+    },
+  },
+});

--- a/military/sanity/militarySchemas/heroes/courseGridBlock.ts
+++ b/military/sanity/militarySchemas/heroes/courseGridBlock.ts
@@ -1,0 +1,29 @@
+import { defineField, defineType } from 'sanity';
+
+export default defineType({
+  name: 'courseGridBlock',
+  title: 'Course Grid',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'light',
+      title: 'Light Style',
+      type: 'boolean',
+      description: 'Use the light color variant of the grid',
+      initialValue: false,
+    }),
+  ],
+  preview: {
+    select: {
+      light: 'light',
+    },
+    prepare({ light }) {
+      return {
+        title: 'Course Grid',
+        subtitle: light
+          ? 'Renders the hexagon course grid (light)'
+          : 'Renders the hexagon course grid',
+      };
+    },
+  },
+});

--- a/military/sanity/militarySchemas/heroes/courseListBlock.ts
+++ b/military/sanity/militarySchemas/heroes/courseListBlock.ts
@@ -1,0 +1,27 @@
+import { defineField, defineType } from 'sanity';
+
+export default defineType({
+  name: 'courseListBlock',
+  title: 'Course List',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'showDivider',
+      title: 'Show divider line below list',
+      type: 'boolean',
+      initialValue: true,
+    }),
+  ],
+  preview: {
+    select: {
+      showDivider: 'showDivider',
+    },
+    prepare({ showDivider }) {
+      return {
+        title: 'Course List',
+        subtitle:
+          showDivider === false ? 'Renders the course list' : 'Renders the course list, divider on',
+      };
+    },
+  },
+});

--- a/military/sanity/militarySchemas/heroes/footerHero.ts
+++ b/military/sanity/militarySchemas/heroes/footerHero.ts
@@ -1,0 +1,41 @@
+import { defineField, defineType } from 'sanity';
+
+export default defineType({
+  name: 'footerHero',
+  title: 'Footer Picture',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+      options: {
+        hotspot: true,
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'quote',
+      title: 'Quote',
+      type: 'string',
+    }),
+    defineField({
+      name: 'quoteAuthor',
+      title: 'Quote Author',
+      type: 'string',
+    }),
+  ],
+  preview: {
+    select: {
+      subtitle: 'quote',
+      media: 'image',
+    },
+    prepare({ subtitle, media }) {
+      return {
+        title: 'Footer Picture',
+        subtitle: subtitle ? `"${subtitle}"` : undefined,
+        media,
+      };
+    },
+  },
+});

--- a/military/sanity/militarySchemas/heroes/heroQuote.ts
+++ b/military/sanity/militarySchemas/heroes/heroQuote.ts
@@ -1,0 +1,76 @@
+import { defineField, defineType } from 'sanity';
+
+export default defineType({
+  name: 'heroQuote',
+  title: 'Hero with Quote',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+      options: {
+        hotspot: true,
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+    }),
+    defineField({
+      name: 'subTitle',
+      title: 'Subtitle',
+      type: 'string',
+    }),
+    defineField({
+      name: 'titleColor',
+      title: 'Title Color',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'White', value: 'white' },
+          { title: 'Black', value: 'black' },
+        ],
+      },
+      initialValue: 'white',
+    }),
+    defineField({
+      name: 'quote',
+      title: 'Quote',
+      type: 'string',
+    }),
+    defineField({
+      name: 'quoteAuthor',
+      title: 'Quote Author',
+      type: 'string',
+    }),
+    defineField({
+      name: 'quoteColor',
+      title: 'Quote Color',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'White', value: 'white' },
+          { title: 'Black', value: 'black' },
+        ],
+      },
+      initialValue: 'white',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'quote',
+      media: 'image',
+    },
+    prepare({ title, subtitle, media }) {
+      return {
+        title: title || 'Hero with Quote',
+        subtitle: subtitle ? `"${subtitle}"` : 'Title & Quote',
+        media,
+      };
+    },
+  },
+});

--- a/military/sanity/militarySchemas/heroes/index.ts
+++ b/military/sanity/militarySchemas/heroes/index.ts
@@ -1,7 +1,44 @@
 import heroTitle from './heroTitle';
 import heroTitleSubtitle from './heroTitleSubtitle';
 import videoHero from './videoHero';
+import aboutSection from './aboutSection';
+import heroQuote from './heroQuote';
+import footerHero from './footerHero';
+import courseGridBlock from './courseGridBlock';
+import courseListBlock from './courseListBlock';
 
-export const heroSchemas = [heroTitle, heroTitleSubtitle, videoHero];
+export const heroSchemas = [
+  heroTitle,
+  heroTitleSubtitle,
+  videoHero,
+  aboutSection,
+  heroQuote,
+  footerHero,
+  courseGridBlock,
+  courseListBlock,
+];
 
-export { heroTitle, heroTitleSubtitle, videoHero };
+// Shared `of` list for any page's block-based `sections`/`heroes` array.
+// Add a new block type to heroSchemas above, then here, to make it
+// available on every page that uses pageSectionBlocks.
+export const pageSectionBlocks = [
+  { type: 'heroTitle' },
+  { type: 'heroTitleSubtitle' },
+  { type: 'heroQuote' },
+  { type: 'videoHero' },
+  { type: 'aboutSection' },
+  { type: 'footerHero' },
+  { type: 'courseGridBlock' },
+  { type: 'courseListBlock' },
+];
+
+export {
+  heroTitle,
+  heroTitleSubtitle,
+  videoHero,
+  aboutSection,
+  heroQuote,
+  footerHero,
+  courseGridBlock,
+  courseListBlock,
+};

--- a/military/sanity/militarySchemas/militaryAboutPage.ts
+++ b/military/sanity/militarySchemas/militaryAboutPage.ts
@@ -1,4 +1,5 @@
 import { defineType, defineField } from 'sanity';
+import { pageSectionBlocks } from './heroes';
 
 export default defineType({
   name: 'militaryAboutPage',
@@ -6,76 +7,18 @@ export default defineType({
   type: 'document',
   fields: [
     defineField({
-      name: 'image1',
-      title: 'Image 1',
-      type: 'image',
-      options: {
-        hotspot: true,
-      },
-    }),
-    defineField({
-      name: 'image1_title',
-      title: 'Image 1 Title',
-      type: 'string',
-    }),
-    defineField({
-      name: 'image1_subTitle',
-      title: 'Image 1 Subtitle',
-      type: 'text',
-      rows: 3,
-    }),
-    defineField({
       name: 'sections',
-      title: 'Video / Hero Sections',
+      title: 'Page Sections',
       type: 'array',
-      description:
-        'Optional blocks (videos or heroes) shown below the main hero, above the Origins section',
-      of: [
-        { type: 'heroTitle' },
-        { type: 'heroTitleSubtitle' },
-        { type: 'videoHero' },
-      ],
-    }),
-    defineField({
-      name: 'image3',
-      title: 'Origins Image',
-      type: 'image',
-      options: {
-        hotspot: true,
-      },
-    }),
-    defineField({
-      name: 'image3_title',
-      title: 'Origins Title',
-      type: 'string',
-    }),
-    defineField({
-      name: 'image3_subTitle',
-      title: 'Origins Subtitle',
-      type: 'array',
-      of: [{ type: 'block' }],
-    }),
-    defineField({
-      name: 'facilities_title',
-      title: 'Facilities Title',
-      type: 'string',
-    }),
-    defineField({
-      name: 'facilities_text',
-      title: 'facilities Text',
-      type: 'array',
-      of: [{ type: 'block' }],
-    }),
-    defineField({
-      name: 'selection_title',
-      title: 'Selection Title',
-      type: 'string',
-    }),
-    defineField({
-      name: 'selection_text',
-      title: 'Selection Text',
-      type: 'array',
-      of: [{ type: 'block' }],
+      description: 'Blocks making up the page',
+      of: pageSectionBlocks,
     }),
   ],
+  preview: {
+    prepare() {
+      return {
+        title: 'About Page',
+      };
+    },
+  },
 });

--- a/military/sanity/militarySchemas/militaryAboutPage.ts
+++ b/military/sanity/militarySchemas/militaryAboutPage.ts
@@ -25,6 +25,18 @@ export default defineType({
       rows: 3,
     }),
     defineField({
+      name: 'sections',
+      title: 'Video / Hero Sections',
+      type: 'array',
+      description:
+        'Optional blocks (videos or heroes) shown below the main hero, above the Origins section',
+      of: [
+        { type: 'heroTitle' },
+        { type: 'heroTitleSubtitle' },
+        { type: 'videoHero' },
+      ],
+    }),
+    defineField({
       name: 'image3',
       title: 'Origins Image',
       type: 'image',

--- a/military/sanity/militarySchemas/militaryCoursesPage.ts
+++ b/military/sanity/militarySchemas/militaryCoursesPage.ts
@@ -1,4 +1,5 @@
 import { defineType, defineField } from 'sanity';
+import { pageSectionBlocks } from './heroes';
 
 export default defineType({
   name: 'militaryCoursesPage',
@@ -6,69 +7,18 @@ export default defineType({
   type: 'document',
   fields: [
     defineField({
-      name: 'heroImage',
-      title: 'Hero Image',
-      type: 'image',
-      options: {
-        hotspot: true,
-      },
-    }),
-    defineField({
-      name: 'title',
-      title: 'Page Title',
-      type: 'string',
-    }),
-    defineField({
-      name: 'subtitle',
-      title: 'Page Subtitle',
-      type: 'text',
-      rows: 2,
-    }),
-    defineField({
-      name: 'titleColor',
-      title: 'Title Color',
-      type: 'string',
-      options: {
-        list: ['white', 'black'],
-      },
-    }),
-    defineField({
-      name: 'heroImageQuote',
-      title: 'Hero Image Quote',
-      type: 'string',
-    }),
-    defineField({
-      name: 'heroImageQuoteAuthor',
-      title: 'Hero Image Quote Author',
-      type: 'string',
-    }),
-    defineField({
-      name: 'quoteColor',
-      title: 'Quote Color',
-      type: 'string',
-      options: {
-        list: ['white', 'black'],
-      },
-    }),
-    defineField({
       name: 'sections',
-      title: 'Video / Hero Sections',
+      title: 'Page Sections',
       type: 'array',
-      description:
-        'Optional blocks (videos or heroes) shown between the hero and the course lists',
-      of: [
-        { type: 'heroTitle' },
-        { type: 'heroTitleSubtitle' },
-        { type: 'videoHero' },
-      ],
-    }),
-    defineField({
-      name: 'footerImage',
-      title: 'Page Footer Image',
-      type: 'image',
-      options: {
-        hotspot: true,
-      },
+      description: 'Blocks making up the page',
+      of: pageSectionBlocks,
     }),
   ],
+  preview: {
+    prepare() {
+      return {
+        title: 'Courses Page',
+      };
+    },
+  },
 });

--- a/military/sanity/militarySchemas/militaryCoursesPage.ts
+++ b/military/sanity/militarySchemas/militaryCoursesPage.ts
@@ -51,6 +51,18 @@ export default defineType({
       },
     }),
     defineField({
+      name: 'sections',
+      title: 'Video / Hero Sections',
+      type: 'array',
+      description:
+        'Optional blocks (videos or heroes) shown between the hero and the course lists',
+      of: [
+        { type: 'heroTitle' },
+        { type: 'heroTitleSubtitle' },
+        { type: 'videoHero' },
+      ],
+    }),
+    defineField({
       name: 'footerImage',
       title: 'Page Footer Image',
       type: 'image',

--- a/military/sanity/militarySchemas/militaryLandingPage.ts
+++ b/military/sanity/militarySchemas/militaryLandingPage.ts
@@ -1,4 +1,5 @@
 import { defineField, defineType } from 'sanity';
+import { pageSectionBlocks } from './heroes';
 
 export default defineType({
   name: 'militaryLandingPage',
@@ -7,53 +8,17 @@ export default defineType({
   fields: [
     defineField({
       name: 'heroes',
-      title: 'Hero Sections',
+      title: 'Page Sections',
+      description: 'Blocks making up the page',
       type: 'array',
-      of: [
-        { type: 'heroTitle' },
-        { type: 'heroTitleSubtitle' },
-        { type: 'videoHero' },
-      ],
-    }),
-    // Legacy fields - kept for migration, can be removed after data is migrated
-    defineField({
-      name: 'image1',
-      title: '[Legacy] Image 1',
-      type: 'image',
-      options: { hotspot: true },
-      hidden: true,
-    }),
-    defineField({
-      name: 'image1_title',
-      title: '[Legacy] Image 1 Title',
-      type: 'string',
-      hidden: true,
-    }),
-    defineField({
-      name: 'image2',
-      title: '[Legacy] Image 2',
-      type: 'image',
-      options: { hotspot: true },
-      hidden: true,
-    }),
-    defineField({
-      name: 'image2_title',
-      title: '[Legacy] Image 2 Title',
-      type: 'string',
-      hidden: true,
-    }),
-    defineField({
-      name: 'image2_subTitle',
-      title: '[Legacy] Image 2 Subtitle',
-      type: 'string',
-      hidden: true,
-    }),
-    defineField({
-      name: 'image3',
-      title: '[Legacy] Image 3',
-      type: 'image',
-      options: { hotspot: true },
-      hidden: true,
+      of: pageSectionBlocks,
     }),
   ],
+  preview: {
+    prepare() {
+      return {
+        title: 'Home Page',
+      };
+    },
+  },
 });

--- a/military/sanity/sanity-military-utils.ts
+++ b/military/sanity/sanity-military-utils.ts
@@ -51,6 +51,34 @@ const heroBlocksProjection = `
       "muxPlaybackId": video.asset->playbackId,
       title,
       autoPlay
+    },
+    _type == "aboutSection" => {
+      "image": image.asset->url,
+      "hotspot": image.hotspot,
+      title,
+      subTitle
+    },
+    _type == "heroQuote" => {
+      "image": image.asset->url,
+      "hotspot": image.hotspot,
+      title,
+      subTitle,
+      titleColor,
+      quote,
+      quoteAuthor,
+      quoteColor
+    },
+    _type == "footerHero" => {
+      "image": image.asset->url,
+      "hotspot": image.hotspot,
+      quote,
+      quoteAuthor
+    },
+    _type == "courseGridBlock" => {
+      light
+    },
+    _type == "courseListBlock" => {
+      showDivider
     }
 `;
 
@@ -89,7 +117,58 @@ export type VideoHeroBlock = {
   autoPlay?: boolean;
 };
 
-export type HeroBlock = HeroTitleBlock | HeroTitleSubtitleBlock | VideoHeroBlock;
+export type AboutSectionBlock = {
+  _type: 'aboutSection';
+  _key: string;
+  image?: string;
+  hotspot?: SanityHotspot | null;
+  title?: string;
+  subTitle?: PortableTextBlock[];
+};
+
+export type HeroQuoteBlock = {
+  _type: 'heroQuote';
+  _key: string;
+  image: string;
+  hotspot: SanityHotspot | null;
+  title?: string;
+  subTitle?: string;
+  titleColor?: 'white' | 'black';
+  quote?: string;
+  quoteAuthor?: string;
+  quoteColor?: 'white' | 'black';
+};
+
+export type FooterHeroBlock = {
+  _type: 'footerHero';
+  _key: string;
+  image: string;
+  hotspot: SanityHotspot | null;
+  quote?: string;
+  quoteAuthor?: string;
+};
+
+export type CourseGridBlock = {
+  _type: 'courseGridBlock';
+  _key: string;
+  light?: boolean;
+};
+
+export type CourseListBlock = {
+  _type: 'courseListBlock';
+  _key: string;
+  showDivider?: boolean;
+};
+
+export type HeroBlock =
+  | HeroTitleBlock
+  | HeroTitleSubtitleBlock
+  | VideoHeroBlock
+  | AboutSectionBlock
+  | HeroQuoteBlock
+  | FooterHeroBlock
+  | CourseGridBlock
+  | CourseListBlock;
 
 export type LandingPageQuery = {
   _id: string;
@@ -108,42 +187,13 @@ export async function getLandingPage(): Promise<LandingPageQuery> {
 const aboutPageQuery = groq`*[_type == "militaryAboutPage"][0]{
   _id,
   _createdAt,
-  "image1": image1.asset->url,
-  "image1_hotspot": image1.hotspot,
-  image1_title,
-  image1_subTitle,
   sections[] {${heroBlocksProjection}},
-  "image2_hotspot": image2.hotspot,
-  "image3": image3.asset->url,
-  "image3_hotspot": image3.hotspot,
-  image3_title,
-  image3_subTitle,
-  facilities_title,
-  facilities_text,
-  selection_title,
-  selection_text,
 }`;
 
 export type AboutPageQuery = {
   _id: string;
   _createdAt: Date;
-  image1: string;
-  image1_hotspot: SanityHotspot;
-  image1_title: string;
-  image1_subTitle: string;
   sections?: HeroBlock[];
-  image2: string;
-  image2_hotspot: SanityHotspot;
-  image2_title: string;
-  image2_subTitle: PortableTextBlock[];
-  image3: string;
-  image3_hotspot: SanityHotspot;
-  image3_title: string;
-  image3_subTitle: PortableTextBlock[];
-  facilities_title: string;
-  facilities_text: PortableTextBlock[];
-  selection_title: string;
-  selection_text: PortableTextBlock[];
 };
 
 export async function getAboutPage(): Promise<AboutPageQuery> {
@@ -157,33 +207,13 @@ export async function getAboutPage(): Promise<AboutPageQuery> {
 const militaryCoursesPageQuery = groq`*[_type == "militaryCoursesPage"][0]{
   _id,
   _createdAt,
-  "heroImage": heroImage.asset->url,
-  "heroImage_hotspot": heroImage.hotspot,
-  title,
-  subtitle,
-  titleColor,
-  heroImageQuote,
-  heroImageQuoteAuthor,
-  quoteColor,
   sections[] {${heroBlocksProjection}},
-  "footerImage": footerImage.asset->url,
-  "footerImage_hotspot": footerImage.hotspot,
 }`;
 
 export type MilitaryCoursesPageQuery = {
   _id: string;
   _createdAt: Date;
-  heroImage: string;
-  heroImage_hotspot: SanityHotspot;
-  title: string;
-  subtitle: string;
-  titleColor: string;
-  heroImageQuote: string;
-  heroImageQuoteAuthor: string;
-  quoteColor: string;
   sections?: HeroBlock[];
-  footerImage: string;
-  footerImage_hotspot: SanityHotspot;
 };
 
 export async function getMilitaryCoursesPage(): Promise<MilitaryCoursesPageQuery> {

--- a/military/sanity/sanity-military-utils.ts
+++ b/military/sanity/sanity-military-utils.ts
@@ -29,10 +29,7 @@ export async function getSiteSettings(): Promise<SiteSettingsQuery> {
   );
 }
 
-const landingPageQuery = groq`*[_type == "militaryLandingPage"][0]{
-  _id,
-  _createdAt,
-  heroes[] {
+const heroBlocksProjection = `
     _type,
     _key,
     _type == "heroTitle" => {
@@ -55,7 +52,12 @@ const landingPageQuery = groq`*[_type == "militaryLandingPage"][0]{
       title,
       autoPlay
     }
-  }
+`;
+
+const landingPageQuery = groq`*[_type == "militaryLandingPage"][0]{
+  _id,
+  _createdAt,
+  heroes[] {${heroBlocksProjection}}
 }`;
 
 export type HeroTitleBlock = {
@@ -110,6 +112,7 @@ const aboutPageQuery = groq`*[_type == "militaryAboutPage"][0]{
   "image1_hotspot": image1.hotspot,
   image1_title,
   image1_subTitle,
+  sections[] {${heroBlocksProjection}},
   "image2_hotspot": image2.hotspot,
   "image3": image3.asset->url,
   "image3_hotspot": image3.hotspot,
@@ -128,6 +131,7 @@ export type AboutPageQuery = {
   image1_hotspot: SanityHotspot;
   image1_title: string;
   image1_subTitle: string;
+  sections?: HeroBlock[];
   image2: string;
   image2_hotspot: SanityHotspot;
   image2_title: string;
@@ -161,6 +165,7 @@ const militaryCoursesPageQuery = groq`*[_type == "militaryCoursesPage"][0]{
   heroImageQuote,
   heroImageQuoteAuthor,
   quoteColor,
+  sections[] {${heroBlocksProjection}},
   "footerImage": footerImage.asset->url,
   "footerImage_hotspot": footerImage.hotspot,
 }`;
@@ -176,6 +181,7 @@ export type MilitaryCoursesPageQuery = {
   heroImageQuote: string;
   heroImageQuoteAuthor: string;
   quoteColor: string;
+  sections?: HeroBlock[];
   footerImage: string;
   footerImage_hotspot: SanityHotspot;
 };


### PR DESCRIPTION
## Summary
- Replaces the hardcoded hero/section fields on the Landing, About, and Courses pages with a single shared set of Sanity block types
- All blocks (hero w/ title, hero w/ subtitle, hero w/ quote, video hero, about section, footer picture, course grid, course list) are now available on every page, in any order
- Adding a new block type going forward only requires updating `heroes/index.ts` once

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Rebuild page content in Sanity Studio for Landing, About, and Courses pages using the new `sections`/`heroes` block array
- [x] Verify each page renders correctly in preview, including the course list divider toggle and course grid light-style toggle